### PR TITLE
[RFC] Add prisma script to package.json

### DIFF
--- a/.changeset/five-boats-raise.md
+++ b/.changeset/five-boats-raise.md
@@ -1,0 +1,5 @@
+---
+'keystone-app': minor
+---
+
+Added `prisma` script to `package.json` to run `keystone-next prisma`.

--- a/create-keystone-app/starter/package.json
+++ b/create-keystone-app/starter/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "keystone-next dev",
-    "start": "keystone-next start",
+    "postinstall": "keystone-next postinstall",
     "build": "keystone-next build",
-    "postinstall": "keystone-next postinstall"
+    "start": "keystone-next start",
+    "prisma": "keystone-next prisma"
   },
   "dependencies": {
     "@keystone-next/auth": "^20.0.0",


### PR DESCRIPTION
Should we add `prisma` as a script to the `package.json`? On the one hand, this lets people easily use `keystone-next prisma` via `yarn prisma`, which makes it consistent with the other script. It also provides a safety net to ensure that the Prisma schema matches the keystone schema. One the other hand, this may cause unexpected behaviour for users who expect `yarn prisma` to run Prisma directly.

This PR also reorders the scripts to match what's written at https://next.keystonejs.com/guides/cli