### PR TITLE
Add engines requirement

### DIFF
--- a/.changeset/dull-points-joke.md
+++ b/.changeset/dull-points-joke.md
@@ -1,0 +1,6 @@
+---
+'keystone-app': minor
+'create-keystone-app': minor
+---
+
+Added engines to package.json to indicate required version of Node.js to run Keystone.

--- a/create-keystone-app/starter/package.json
+++ b/create-keystone-app/starter/package.json
@@ -13,5 +13,8 @@
     "@keystone-next/fields-document": "^12.0.0",
     "@keystone-next/keystone": "^27.0.1",
     "typescript": "^4.4.4"
+  },
+  "engines": {
+    "node": "^12.20 || >= 14.13"
   }
 }


### PR DESCRIPTION
It's not clear what minimum version of Node you need to run Keystone, adding this in to match the config in the main Keystone repo.

_Related Keystone Community Slack thread - https://keystonejs.slack.com/archives/C01STDMEW3S/p1636388435188400_