### PR TITLE
Allow connecting an author on post creation

### DIFF
--- a/create-keystone-app/starter/schema.ts
+++ b/create-keystone-app/starter/schema.ts
@@ -111,6 +111,7 @@ export const lists: Lists = {
           cardFields: ['name', 'email'],
           inlineEdit: { fields: ['name', 'email'] },
           linkToItem: true,
+          inlineConnect: true,
           inlineCreate: { fields: ['name', 'email'] },
         },
       }),


### PR DESCRIPTION
Right now when you create your first post (the very likely first action someone would do when discovering this starter), you cannot connect a user (author) to that new post.

Creating a new user there does not necessarily make sense (at least in my head 😅) and I think allowing the editor to connect that post to the existing user sort of makes sense?

<img width="360" alt="image" src="https://user-images.githubusercontent.com/485747/156878056-87486946-0f8c-4a42-993b-d4cbec246791.png">