### PR TITLE
Setup automated publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,33 +1,35 @@
-name: Release
+name: Publish
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  release:
-    name: Release
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@main
+        uses: actions/checkout@master
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js LTS
-        uses: actions/setup-node@main
+        uses: actions/setup-node@master
         with:
           node-version: lts/*
 
       - name: Install Dependencies
-        run: yarn
+        # we have a postinstall script that uses is-ci which doesn't yet detect GitHub Actions
+        run: CI=true yarn
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Publish to npm
         uses: changesets/action@v1
         with:
+          version: yarn no-run-version-packages
           publish: yarn publish-changed
+          createGithubReleases: false
         env:
           # note that we're not using the GH token provided by Actions here because Actions has a rule that Actions
           # will not run as the result of another Action so CI wouldn't run on the release PRs then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: Create Release Pull Request
-        uses: changesets/action@master
+      - name: Create Release Pull Request or Publish to npm
+        uses: changesets/action@v1
+        with:
+          publish: yarn publish-changed
         env:
           # note that we're not using the GH token provided by Actions here because Actions has a rule that Actions
           # will not run as the result of another Action so CI wouldn't run on the release PRs then
           # we can get around it by using a personal access token from a GH account
           GITHUB_TOKEN: ${{ secrets.KEYSTONE_RELEASE_BOT_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -1,0 +1,36 @@
+name: Create Release PR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@master
+        with:
+          node-version: lts/*
+
+      - name: Install Dependencies
+        # we have a postinstall script that uses is-ci which doesn't yet detect GitHub Actions
+        run: CI=true yarn
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          version: yarn version-packages
+        env:
+          # note that we're not using the GH token provided by Actions here because Actions has a rule that Actions
+          # will not run as the result of another Action so CI wouldn't run on the release PRs then
+          # we can get around it by using a personal access token from a GH account
+          GITHUB_TOKEN: ${{ secrets.KEYSTONE_RELEASE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -11,24 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js LTS
-        uses: actions/setup-node@master
+        uses: actions/setup-node@main
         with:
           node-version: lts/*
 
       - name: Install Dependencies
-        # we have a postinstall script that uses is-ci which doesn't yet detect GitHub Actions
-        run: CI=true yarn
+        run: yarn
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
-        with:
-          version: yarn version-packages
         env:
           # note that we're not using the GH token provided by Actions here because Actions has a rule that Actions
           # will not run as the result of another Action so CI wouldn't run on the release PRs then

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "lint:types": "tsc",
     "test": "yarn lint:prettier && yarn lint:types",
     "test:unit": "DATABASE_URL=file:./keystone.db yarn jest",
-    "publish-changed": "yarn build && changeset publish"
+    "publish-changed": "yarn build && changeset publish",
+    "no-run-version-packages": "echo \"This workflow should not be run when there are changesets on main\" && exit 1"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
This uses https://github.com/changesets/action in a slightly weird way now.

We still use the Action to create the PR(and not publish) and that's unchanged.

Now there's a new workflow that _also_ runs the Changesets Action but:
- it's assumed it will only run when there are no changesets so it only does publishing 
- it's triggered by a workflow dispatch
- it requires approval to allow the npm token to be used (this is separate to the workflow dispatch)

(re why use the action and not just run `changeset publish`: I didn't want to worry about how to get npm authenticated, getting git authenticated with the right credentials and pushing tags so I just used the action since I know It'll Work)