### PR TITLE
Use graphql@15.8 to prevent conflicting graphql instances

### DIFF
--- a/create-keystone-app/starter/package.json
+++ b/create-keystone-app/starter/package.json
@@ -12,6 +12,7 @@
     "@keystone-6/auth": "^4.0.0",
     "@keystone-6/core": "^2.1.0",
     "@keystone-6/fields-document": "^4.0.1",
+    "graphql": "^15.8.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/two-versions-conflict.md
+++ b/two-versions-conflict.md
@@ -1,0 +1,6 @@
+---
+'create-keystone-app': patch
+'keystone-app': patch
+---
+
+Use `graphql@^15.8.0` in the project root until https://github.com/keystonejs/keystone/issues/7816 is resolved


### PR DESCRIPTION
See issue https://github.com/keystonejs/keystone/issues/7816