### PR TITLE
Update schemas

### DIFF
--- a/.changeset/update-the-schemas.md
+++ b/.changeset/update-the-schemas.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-app': patch
+---
+
+Upgrades `@keystone-6/*` to the newest patch release

--- a/.changeset/update-the-schemas.md
+++ b/.changeset/update-the-schemas.md
@@ -1,5 +1,5 @@
 ---
-'create-keystone-app': patch
+'create-keystone-app': minor
 ---
 
-Upgrades `@keystone-6/*` to the newest patch release
+Upgrades `@keystone-6/*` to the newest minor release

--- a/create-keystone-app/starter/package.json
+++ b/create-keystone-app/starter/package.json
@@ -9,9 +9,9 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/auth": "^5.0.0",
-    "@keystone-6/core": "^3.0.1",
-    "@keystone-6/fields-document": "^5.0.0",
+    "@keystone-6/auth": "^5.0.1",
+    "@keystone-6/core": "^3.1.2",
+    "@keystone-6/fields-document": "^5.0.2",
     "typescript": "^4.8.0"
   }
 }

--- a/create-keystone-app/starter/schema.graphql
+++ b/create-keystone-app/starter/schema.graphql
@@ -340,9 +340,10 @@ type KeystoneAdminUIListMeta {
   pageSize: Int!
   labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
+  groups: [KeystoneAdminUIFieldGroupMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
-  isSingleton: Boolean
+  isSingleton: Boolean!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -380,6 +381,7 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
@@ -388,9 +390,20 @@ enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   hidden
 }
 
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
+}
+
 enum QueryMode {
   default
   insensitive
+}
+
+type KeystoneAdminUIFieldGroupMeta {
+  label: String!
+  description: String
+  fields: [KeystoneAdminUIFieldMeta!]!
 }
 
 type KeystoneAdminUISort {

--- a/index.test.ts
+++ b/index.test.ts
@@ -120,7 +120,7 @@ describe.each(['development', 'production'] as const)('%s', (mode) => {
 
     test('create user', async () => {
       await page.goto('http://localhost:3000');
-      await page.fill('label:has-text("Name") >> .. >> input', 'Admin');
+      await page.fill('label:has-text("Name") >> .. >> input', 'Admin1');
       await page.fill(
         'label:has-text("Email") >> .. >> input',
         'admin@keystonejs.com'
@@ -135,11 +135,11 @@ describe.each(['development', 'production'] as const)('%s', (mode) => {
 
     test('change admin name', async () => {
       await page.click('h3:has-text("Users")');
-      await page.click('a:has-text("Admin")');
-      await page.type('label:has-text("Name") >> .. >> input', '1');
+      await page.click('a:has-text("Admin1")');
+      await page.fill('label:has-text("Name") >> .. >> input', 'Admin2');
       await page.click('button:has-text("Save changes")');
       await page.click('nav >> text=Users');
-      expect(await page.textContent('a:has-text("Admin1")')).toBe('Admin1');
+      expect(await page.textContent('a:has-text("Admin2")')).toBe('Admin2');
     });
 
     test('create a post', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,25 +3074,25 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-5.4.2.tgz#fedb8b4b98cf0750daf5802fa2a661edbf83892b"
   integrity sha512-QIDIZ9a0NfDStgD47VaTgwiPjlw1p4QPLwjOB/9+/DqIztoQopPNNAd+HdtQMHgE+ibP3dJacd8/TVL/A1RaaA==
 
-"@keystone-6/auth@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@keystone-6/auth/-/auth-5.0.0.tgz#379a0c1bcab705a4ac19e9b33991b2b56866ea65"
-  integrity sha512-1yh3BN88ceuvXG2jt8kZ4yvLoIQD556kU+Hl8wWvHDhUnZwbnfXtUODVXqOYLxB/pt+4nQEDEqdcZ0s5hdbOiw==
+"@keystone-6/auth@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@keystone-6/auth/-/auth-5.0.1.tgz#bf1c280c9edbffb315e507d1f34f3a10d519c1c4"
+  integrity sha512-q7IXrX4XXkdXVHDIEbxRzzgcz5wX4r3zpt2TEAlsIi63ZaGgeUFKV6RUq2AR7W2zq4kE9aB4gaNL6oqPyYui+g==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/button" "^7.0.1"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/fields" "^7.1.1"
-    "@keystone-ui/loading" "^6.0.1"
-    "@keystone-ui/notice" "^6.0.1"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/fields" "^7.1.2"
+    "@keystone-ui/loading" "^6.0.2"
+    "@keystone-ui/notice" "^6.0.2"
     cross-fetch "^3.1.4"
     fast-deep-equal "^3.1.3"
     graphql "^16.6.0"
 
-"@keystone-6/core@^3.0.1":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@keystone-6/core/-/core-3.0.2.tgz#ac578ad0c95b3c4884593a692562bc605418bc68"
-  integrity sha512-vZt7zcWiBXmRv8j6d/ZEKQQgqip2VzzPzVSuH0QIsIYBeRLtAQ0NdjflFJlHAsJ9R//OlbVNPk+TRRSG3uilwg==
+"@keystone-6/core@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@keystone-6/core/-/core-3.1.2.tgz#e9b0dc3d51c970c54c860e96d50707427ffa4162"
+  integrity sha512-LmU2PoW318vQLve0F5Q6Fa8tNafmMLkKPTobyZrSh+gr7UC40ZBizr+VfDy9BCCfJhuM767fXp1Iy9/FHFBCSw==
   dependencies:
     "@apollo/client" "^3.7.0"
     "@aws-sdk/client-s3" "^3.83.0"
@@ -3105,19 +3105,19 @@
     "@graphql-ts/schema" "^0.6.0"
     "@graphql-typed-document-node/core" "3.1.1"
     "@hapi/iron" "^6.0.0"
-    "@keystone-ui/button" "^7.0.1"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/fields" "^7.1.1"
-    "@keystone-ui/icons" "^6.0.1"
-    "@keystone-ui/loading" "^6.0.1"
-    "@keystone-ui/modals" "^6.0.1"
-    "@keystone-ui/notice" "^6.0.1"
-    "@keystone-ui/options" "^6.0.1"
-    "@keystone-ui/pill" "^7.0.1"
-    "@keystone-ui/popover" "^6.0.1"
-    "@keystone-ui/segmented-control" "^7.0.1"
-    "@keystone-ui/toast" "^6.0.1"
-    "@keystone-ui/tooltip" "^6.0.1"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/fields" "^7.1.2"
+    "@keystone-ui/icons" "^6.0.2"
+    "@keystone-ui/loading" "^6.0.2"
+    "@keystone-ui/modals" "^6.0.2"
+    "@keystone-ui/notice" "^6.0.2"
+    "@keystone-ui/options" "^6.0.2"
+    "@keystone-ui/pill" "^7.0.2"
+    "@keystone-ui/popover" "^6.0.2"
+    "@keystone-ui/segmented-control" "^7.0.2"
+    "@keystone-ui/toast" "^6.0.2"
+    "@keystone-ui/tooltip" "^6.0.2"
     "@nodelib/fs.walk" "^1.2.8"
     "@preconstruct/next" "^4.0.0"
     "@prisma/client" "4.3.1"
@@ -3181,15 +3181,15 @@
     uid-safe "^2.1.5"
     uuid "^9.0.0"
 
-"@keystone-6/document-renderer@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@keystone-6/document-renderer/-/document-renderer-1.1.1.tgz#cece98bf38ec38953d7bcb8d0e3799aba2af0568"
-  integrity sha512-OziNXEaZwSUWQuA04lbUPzUDyBqc1zxtmw2VAHt51adT6PvTihB58fWhBQ9H17Mytk4Egup4xI3bs7KpG98TOw==
+"@keystone-6/document-renderer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@keystone-6/document-renderer/-/document-renderer-1.1.2.tgz#30f8bbc95ac905ba3971e0699b635172d2aff08e"
+  integrity sha512-fxnQL6xYTK/2xSrZ0dzBTC1Qpa4VVeXmZ+7mMvaZOWquttgvDQzBRY57q9zScRa0dAALNWU1xzq14OL8Kc+eBw==
 
-"@keystone-6/fields-document@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-6/fields-document/-/fields-document-5.0.1.tgz#b1362a5b8996d360f6f45d418aa6be10638c660a"
-  integrity sha512-XecSzT0dWR7z0u5HF7kpscG7eg/mARUp8i9K8NMwaRcXFUbpt+mI305h9Sr2samzE4Oil1rup/KCFj/ET7SCQQ==
+"@keystone-6/fields-document@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-6/fields-document/-/fields-document-5.0.2.tgz#5812afcf65c1581838c8800a0fe47849b7c536cd"
+  integrity sha512-Pg8xnFKu6J6Nz9YHUlVgtqYT5nL6LNU8WAY2gJZ3YV9W/YWmFeiHaE5MC+q2Zg54FqwQ/iHju5mZlGLStGoCqA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@braintree/sanitize-url" "^6.0.0"
@@ -3197,13 +3197,13 @@
     "@dnd-kit/modifiers" "^6.0.0"
     "@dnd-kit/sortable" "^7.0.0"
     "@emotion/weak-memoize" "^0.3.0"
-    "@keystone-6/document-renderer" "^1.1.1"
-    "@keystone-ui/button" "^7.0.1"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/fields" "^7.1.1"
-    "@keystone-ui/icons" "^6.0.1"
-    "@keystone-ui/popover" "^6.0.1"
-    "@keystone-ui/tooltip" "^6.0.1"
+    "@keystone-6/document-renderer" "^1.1.2"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/fields" "^7.1.2"
+    "@keystone-ui/icons" "^6.0.2"
+    "@keystone-ui/popover" "^6.0.2"
+    "@keystone-ui/tooltip" "^6.0.2"
     "@types/react" "^18.0.9"
     apollo-server-errors "^3.3.0"
     apply-ref "^1.0.0"
@@ -3224,139 +3224,139 @@
     slate-history "^0.66.0"
     slate-react "^0.81.0"
 
-"@keystone-ui/button@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/button/-/button-7.0.1.tgz#3a43127d3124b118744d394359bacfc5fc71b7b7"
-  integrity sha512-eA9qSX+Uh2S/6PO7TCcmvtyjtYKDbkHD7l9uTAIsNIKR4YGkSvPUcYBpdSQLPrr1H5aHHhgl+oOiiMiNw4Xudw==
+"@keystone-ui/button@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/button/-/button-7.0.2.tgz#6f3be63b54b517eddd101b3f2d3bb47e281e84f5"
+  integrity sha512-bFuT3WtLRFWXGP0lMPRIxYG22u2BEvjP9blSeGGXQSvl3hC5Zh2r/BlylHeYaWFChcaRYRU2G/2QSLoPAvyDGQ==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/icons" "^6.0.1"
-    "@keystone-ui/loading" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/icons" "^6.0.2"
+    "@keystone-ui/loading" "^6.0.2"
     react "^18.1.0"
 
-"@keystone-ui/core@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/core/-/core-5.0.1.tgz#cff796451ba3dda3064651fc3bc9d157c61ad001"
-  integrity sha512-EXCZ6LCMxMot3IHSHNZiGUk6tE9ippvvtZE+9JU2K2SliqT5sn9RXbet0Bv/FukikUrSyV3azl5ES902swaQdA==
+"@keystone-ui/core@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/core/-/core-5.0.2.tgz#d56af8d7a18afbf608c85f3236424eeb34a325bd"
+  integrity sha512-0/rh2nhuQDyio1I8HWfeHUhHP3Adf9+RcsrtpJfcv+U6W3NsJnL/hX68WOYOSF7vYhFgtnuCx8a57xrK1xTsEQ==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@emotion/react" "^11.7.1"
     "@types/facepaint" "^1.2.2"
     facepaint "^1.2.1"
 
-"@keystone-ui/fields@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/fields/-/fields-7.1.1.tgz#70c5d20b9935b0347c261d3d7aa7dadb57f3c4ad"
-  integrity sha512-ld1XfQYdmq8gIDtTtGRLvIM4YmQ288QJR8/H8Vw1z/YYHnDdIWucY+6QaqZ3uP5K9nGhXk6L+6OInj2uxRklzw==
+"@keystone-ui/fields@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/fields/-/fields-7.1.2.tgz#cb9328096f056b7c6343f1e7e64ef3e4246404b5"
+  integrity sha512-3/PTPTXFu7Iy80KxzRBXjVrdGfWqObpI4rs1dkHdKJoq8TWFWrrcEaglxY9o1GA3v7kClCIBplOIy/PHl+mmBA==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/icons" "^6.0.1"
-    "@keystone-ui/popover" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/icons" "^6.0.2"
+    "@keystone-ui/popover" "^6.0.2"
     date-fns "^2.26.0"
     react "^18.1.0"
     react-day-picker "^8.0.4"
     react-focus-lock "^2.7.1"
     react-select "^5.2.1"
 
-"@keystone-ui/icons@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/icons/-/icons-6.0.1.tgz#3ba3c0d71973af4cbb2de69d34f746caf34a7bd3"
-  integrity sha512-qxuOV/hlShNR84NGfUKiaeoXQAjR+tCJiuRTdspiFfwg8Wzuconr6wq2xlPr6eawTNK/V63ffGsv2rwYqY6UEw==
+"@keystone-ui/icons@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/icons/-/icons-6.0.2.tgz#fb3b6b9a330c9a5244d80e1b8a3a8c8199050c9e"
+  integrity sha512-myJ8AoLxJrcLYAVgH3u+hO6wO/ZeidraLzlwxOyLMgLLBJsWwOOYVRZv2nHp6S/G/gIa6UaCQKC4VI8wjvieVg==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
+    "@keystone-ui/core" "^5.0.2"
 
-"@keystone-ui/loading@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/loading/-/loading-6.0.1.tgz#f67e4f3f43392a5dab1067f7fde7bed3b2b9a094"
-  integrity sha512-ZP2CAAsAWKdzYPOMMoeGGLNeSKJBRrChV2Bp4mqFDPRYtFhyxELzMLjLtFmhOEHKJYFrZOmXP4/GaOJgRthtpA==
+"@keystone-ui/loading@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/loading/-/loading-6.0.2.tgz#ee3296631890e7352978f99bcfff8097e834985c"
+  integrity sha512-s72z2AcMzyVobKlbZ39JbyhtNrf7JMX6WaBYU59612OOXcOCYlc9X6Mt/AKUFYbx2uCOS8E1Fitxc+BT0Xoxwg==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
+    "@keystone-ui/core" "^5.0.2"
     react "^18.1.0"
 
-"@keystone-ui/modals@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/modals/-/modals-6.0.1.tgz#d719da270a0f9a36b0e93229ed1ca9220160a713"
-  integrity sha512-aJvRtkWdmUSqIEARzjuPMpx/vQKkbJXUahBhAe8Oirf5nVn7Ky7nxZ+G45oG7MmvarCgH/PcGQOq5zt/fZBsVw==
+"@keystone-ui/modals@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/modals/-/modals-6.0.2.tgz#2f2c606849be8377854e7e2b5a551f47c4c6e0ac"
+  integrity sha512-6O2oYEg7W/qmA2VFnUEp8rZw3oqePvv2KmW9cM6m2Dw4/M6djOvCexXmALFc6uq4dhzyhLbUb2TW6X1d9QHLBA==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/button" "^7.0.1"
-    "@keystone-ui/core" "^5.0.1"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/core" "^5.0.2"
     react "^18.1.0"
     react-focus-lock "^2.7.1"
     react-remove-scroll "^2.4.3"
     react-transition-group "^4.4.2"
 
-"@keystone-ui/notice@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/notice/-/notice-6.0.1.tgz#737f8a8304511fdf0311a4542f4f0186256dcc85"
-  integrity sha512-l15XA/lfU9rrBFkTmC/SwBb5WUFtkMkaCVHFHmZT/N8HAcOGB06lEYb8CHSN4VUq091XmCMd2nE29KOkh2clJw==
+"@keystone-ui/notice@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/notice/-/notice-6.0.2.tgz#e094b0f26c3695d35eb89447b96ee2e2fbc8c69a"
+  integrity sha512-SodZehvF0a5GmMx3LGXJW4i3QtNDTD9tnrOV+5EUb21f352z6kUVL+UxS9439ZnGvgyWETPYw/ZsGu19lD/2Ag==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/button" "^7.0.1"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/icons" "^6.0.1"
+    "@keystone-ui/button" "^7.0.2"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/icons" "^6.0.2"
     react "^18.1.0"
 
-"@keystone-ui/options@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/options/-/options-6.0.1.tgz#3f5e83468b14f7eb6c9e9972d469b25d8d709c53"
-  integrity sha512-qfiot0wIxcmmXjM7GoalrpPG5dQnYgRyFGrjychZVT+l9N4FVc5EUxsqEu6zN5gaLs2Tvleq2zwGkUk1AteIHQ==
+"@keystone-ui/options@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/options/-/options-6.0.2.tgz#a72e5eeebe17ceadd3dad291cd60f1ffc2741351"
+  integrity sha512-JH5+hI0JNDTF7bTdmDMzrGh9k5tFH89B9AtQlmakLb/rD1ZQ35ztPwNV8U/WH+pyZXC9M72POkEwHMI9paq1mA==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/fields" "^7.1.1"
-    "@keystone-ui/icons" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/fields" "^7.1.2"
+    "@keystone-ui/icons" "^6.0.2"
     react-select "^5.2.1"
 
-"@keystone-ui/pill@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/pill/-/pill-7.0.1.tgz#0131d9616ba8e70b9b2251703f6b4cafb5ecdf82"
-  integrity sha512-yKaO/Pr9d1/ERNHLYex7fxADpCJJK8Zr9rzWv7AUqrMJNa1uMIoOuVAh2As4itzma8G7IinCf3kumSO+rfkdgg==
+"@keystone-ui/pill@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/pill/-/pill-7.0.2.tgz#c74163f4418fbaee9ea15d608e7cb6fed3862f41"
+  integrity sha512-s4V588PvZuJr02ppTE01IgzRTnRCrC47wvwv7u2PLgmyyvP5HPMBOoTuwEIxdY0J8CWAWOOT8HCu+ME68G++HQ==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/icons" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/icons" "^6.0.2"
 
-"@keystone-ui/popover@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/popover/-/popover-6.0.1.tgz#b06033ad4f34ae83abde23f43ac5eeb84a751519"
-  integrity sha512-TxoSqXYSyxA57nkJzsuNQCncFwqCsc/cM9nxzhI3pBoAmAaoR28tO4TDQeYpIWouUg9/eAFK+F/mZQS/fkLfog==
+"@keystone-ui/popover@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/popover/-/popover-6.0.2.tgz#353d2abea1b4b3397d3bec6631d82edd58ae87c9"
+  integrity sha512-E0WBEkoe+e0rjSAOBAFNKNHDVvIhx9YqEcwFLaCUUj6q93O7/gUq6wNrkrTfDAhz5O9tMgLkXE6jAHdvYFk/IQ==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
+    "@keystone-ui/core" "^5.0.2"
     "@popperjs/core" "^2.10.2"
-    focus-trap "^6.7.1"
+    focus-trap "^7.0.0"
     react-popper "^2.2.5"
 
-"@keystone-ui/segmented-control@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/segmented-control/-/segmented-control-7.0.1.tgz#128775834228268ffdcdeb4c7281cd4c0c80034a"
-  integrity sha512-z/d2g2mJEdFpbUqbWpBxbrR7QjdNPKwg1NWkfEHOkdLomDhHCtZaWMJHje9JX9EJAbaY6Ldw+ZbtFNmtQH6ikg==
+"@keystone-ui/segmented-control@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/segmented-control/-/segmented-control-7.0.2.tgz#e83595c14b732c1d002fd386110912571025fa26"
+  integrity sha512-XDeh3AHYX08YoFbKmPIgbI7eoR6LrBdXYqLDTbanMPWzRXl5YHvCODV0pS5/tyDyatqPGH3FjzK9mWOAnaPpkw==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
+    "@keystone-ui/core" "^5.0.2"
 
-"@keystone-ui/toast@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/toast/-/toast-6.0.1.tgz#edef03e9d32affafb1b70eb5e5e6001716557bcb"
-  integrity sha512-Fqbt/KcGhEOCeseElxo1GbzrAJn35g6j7csE1D5GTn3qwMeTh9IS2y/igIJVKZk3ANKv/2DmbNwmAoOzn189iw==
+"@keystone-ui/toast@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/toast/-/toast-6.0.2.tgz#f2da5b5e71db2847ff65baa7082b841673e3150a"
+  integrity sha512-Q/0UNO58SgnIwmDDsVVjDmPAuM+xWEvXJSx/46FPAKNgHbPZYNewhuW+AHn8iCcP5xScByAIcqql5FRXKBxidA==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/icons" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/icons" "^6.0.2"
 
-"@keystone-ui/tooltip@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@keystone-ui/tooltip/-/tooltip-6.0.1.tgz#897b8ee8ee19195e709add60be04e6bcf234ff90"
-  integrity sha512-6BJMjmvqVVJNUIQqzPuMc9+hY4mcyWD6EJfolOYKDfzUCgZLa+TsSk8wOB61AxDMumWh9H+Uh1F4Gw8uA6cMHg==
+"@keystone-ui/tooltip@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@keystone-ui/tooltip/-/tooltip-6.0.2.tgz#f3fd9b068fdf5d0ba011c110a23fdb0aabf106ed"
+  integrity sha512-lB+1TCcXvM2R8wKg7Wd7VIY10RaKjQXR/BKUf+trozl9v/NuFEX3Ym5GvanDQXyQgwfUC6xvUX3IuHjdhCrJIw==
   dependencies:
     "@babel/runtime" "^7.16.3"
-    "@keystone-ui/core" "^5.0.1"
-    "@keystone-ui/popover" "^6.0.1"
+    "@keystone-ui/core" "^5.0.2"
+    "@keystone-ui/popover" "^6.0.2"
     apply-ref "^1.0.0"
 
 "@manypkg/cli@^0.19.1":
@@ -6183,12 +6183,12 @@ focus-lock@^0.11.2:
   dependencies:
     tslib "^2.0.3"
 
-focus-trap@^6.7.1:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.4.tgz#436da1a1d935c48b97da63cd8f361c6f3aa16444"
-  integrity sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==
+focus-trap@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.1.0.tgz#3226e977d76b1fd555c2e4f7ff91f10371f0f2cc"
+  integrity sha512-CuJvwUBfJCWcU6fc4xr3UwMF5vWnox4isXAixCwrPzCsPKOQjP9T+nTlYT2t+vOmQL8MOQ16eim99XhjQHAuiQ==
   dependencies:
-    tabbable "^5.3.3"
+    tabbable "^6.0.1"
 
 form-data@4.0.0, form-data@^4.0.0:
   version "4.0.0"
@@ -9890,10 +9890,10 @@ symbol-observable@^4.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
-tabbable@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
-  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
+tabbable@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
+  integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
 
 tar-stream@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Fixes `create-keystone-app` failing at the postinstall, as reported by https://twitter.com/Mikelzsigler/status/1595117120697733120 (@mzsigler)