### PR TITLE
Ignore entire .keystone folder

### DIFF
--- a/create-keystone-app/starter/_gitignore
+++ b/create-keystone-app/starter/_gitignore
@@ -1,4 +1,4 @@
 node_modules
-.keystone/admin
+.keystone/
 keystone.db
 *.log


### PR DESCRIPTION
When building Keystone it creates these files. Right now only the admin folder is ignored, but it should be the entire `.keystone/` folder

- `.keystone/admin/`
- `.keystone/config.js`
- `.keystone/config.js.map`